### PR TITLE
Disable unnecessary workflows in forks

### DIFF
--- a/.github/workflows/clean-up.yml
+++ b/.github/workflows/clean-up.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   del_runs:
     runs-on: ubuntu-latest
+    if: github.event.repository.fork == false
     permissions:
       actions: write
       contents: read

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -28,7 +28,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    if: github.event.repository.fork == false
     steps:
               
       - name: Checkout repository

--- a/.github/workflows/sync-to-cnb.yml
+++ b/.github/workflows/sync-to-cnb.yml
@@ -4,6 +4,7 @@ on: [push]
 jobs:
   sync:
     runs-on: ubuntu-latest
+    if: github.event.repository.fork == false
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
We don't need to run these workflows in the forked repository.